### PR TITLE
Add tests to test the behaviour of bcc tools when run on a remote target via BPFd

### DIFF
--- a/src/cc/CMakeLists.txt
+++ b/src/cc/CMakeLists.txt
@@ -77,6 +77,7 @@ if(ENABLE_USDT)
 endif()
 
 add_subdirectory(frontends)
+add_subdirectory(bpfd)
 
 # Link against LLVM libraries
 target_link_libraries(bcc-shared ${bcc_common_libs_for_s})

--- a/src/cc/bpfd/CMakeLists.txt
+++ b/src/cc/bpfd/CMakeLists.txt
@@ -1,0 +1,5 @@
+# Copyright (c) Jazel Canseco, 2018
+# Licensed under the Apache License, Version 2.0 (the "License")
+
+add_executable(bpfd bpfd.c base64.c remote_perf_reader.c utils.c)
+target_link_libraries(bpfd bpf-static)

--- a/src/cc/bpfd/base64.c
+++ b/src/cc/bpfd/base64.c
@@ -1,0 +1,267 @@
+/*******************************************************************
+
+Base64 Encoding/Decoding Library
+
+Author: freecode http://freecode-freecode.blogspot.com/
+*******************************************************************/
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+/**
+* characters used for Base64 encoding
+*/
+const char *BASE64_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+/**
+* encode three bytes using base64 ( RFC 3548 )
+*
+* @param triple three bytes that should be encoded
+* @param result buffer of four characters where the result is stored
+*/
+void _base64_encode_triple( unsigned char triple[ 3 ] , char result[ 4 ] )
+{
+	int tripleValue, i;
+
+	tripleValue = triple[ 0 ] ;
+	tripleValue *= 256;
+	tripleValue += triple[ 1 ];
+	tripleValue *= 256;
+	tripleValue += triple[ 2 ];
+
+	for ( i=0; i<4; i++ )
+	{
+		result[ 3-i ] = BASE64_CHARS[ tripleValue%64 ];
+		tripleValue /= 64;
+	}
+}
+
+/**
+* encode an array of bytes using Base64 ( RFC 3548 )
+*
+* @param source the source buffer
+* @param sourcelen the length of the source buffer
+* @param target the target buffer
+* @param targetlen the length of the target buffer
+* @return 1 on success, 0 otherwise
+*/
+int base64_encode( unsigned char *source, size_t sourcelen, char *target, size_t targetlen )
+{
+	/* check if the result will fit in the target buffer */
+	if ( ( sourcelen+2 )/3*4 > targetlen-1 )
+		return 0;
+
+	/* encode all full triples */
+	while ( sourcelen >= 3 )
+	{
+		_base64_encode_triple( source, target );
+		sourcelen -= 3;
+		source += 3;
+		target += 4;
+	}
+
+	/* encode the last one or two characters */
+	if ( sourcelen > 0 )
+	{
+		unsigned char temp[ 3 ] ;
+		memset( temp, 0, sizeof( temp ) );
+		memcpy( temp, source, sourcelen );
+		_base64_encode_triple( temp, target );
+		target[ 3 ] = '=';
+		if ( sourcelen == 1 )
+			target[ 2 ] = '=';
+
+		target += 4;
+	}
+
+	/* terminate the string */
+	target[ 0 ] = 0;
+
+	return 1;
+}
+
+/**
+* determine the value of a base64 encoding character
+*
+* @param base64char the character of which the value is searched
+* @return the value in case of success ( 0-63 ), -1 on failure
+*/
+int _base64_char_value( char base64char )
+{
+	if ( base64char >= 'A' && base64char <= 'Z' )
+		return base64char-'A';
+	if ( base64char >= 'a' && base64char <= 'z' )
+		return base64char-'a'+26;
+	if ( base64char >= '0' && base64char <= '9' )
+		return base64char-'0'+2*26;
+	if ( base64char == '+' )
+		return 2*26+10;
+	if ( base64char == '/' )
+		return 2*26+11;
+	return -1;
+}
+
+/**
+* decode a 4 char base64 encoded byte triple
+*
+* @param quadruple the 4 characters that should be decoded
+* @param result the decoded data
+* @return lenth of the result ( 1, 2 or 3 ), 0 on failure
+*/
+int _base64_decode_triple( char quadruple[ 4 ], unsigned char *result )
+{
+	int i, triple_value, bytes_to_decode = 3, only_equals_yet = 1;
+	int char_value[ 4 ];
+
+	for ( i=0; i<4; i++ )
+		char_value[ i ] = _base64_char_value( quadruple[ i ] );
+
+	/* check if the characters are valid */
+	for ( i=3; i>=0; i-- )
+	{
+		if ( char_value[ i ] < 0 )
+		{
+			if ( only_equals_yet && quadruple[ i ] =='=' )
+			{
+				/* we will ignore this character anyway, make it something
+				* that does not break our calculations */
+				char_value[ i ]=0;
+				bytes_to_decode--;
+				continue;
+			}
+			return 0;
+		}
+		/* after we got a real character, no other '=' are allowed anymore */
+		only_equals_yet = 0;
+	}
+
+	/* if we got "====" as input, bytes_to_decode is -1 */
+	if ( bytes_to_decode < 0 )
+		bytes_to_decode = 0;
+
+	/* make one big value out of the partial values */
+	triple_value = char_value[ 0 ];
+	triple_value *= 64;
+	triple_value += char_value[ 1 ] ;
+	triple_value *= 64;
+	triple_value += char_value[ 2 ];
+	triple_value *= 64;
+	triple_value += char_value[ 3 ];
+
+	/* break the big value into bytes */
+	for ( i=bytes_to_decode; i<3; i++ )
+		triple_value /= 256;
+	for ( i=bytes_to_decode-1; i>=0; i-- )
+	{
+		result[ i ] = triple_value%256;
+		triple_value /= 256;
+	}
+
+	return bytes_to_decode;
+}
+
+/**
+* decode base64 encoded data
+*
+* @param source the encoded data ( zero terminated )
+* @param target pointer to the target buffer
+* @param targetlen length of the target buffer
+* @return length of converted data on success, -1 otherwise
+*/
+size_t base64_decode( char *source, unsigned char *target, size_t targetlen )
+{
+	char *src, *tmpptr;
+	char quadruple[ 4 ], tmpresult[ 3 ];
+	int i;
+	int tmplen = 3;
+	size_t converted = 0;
+
+	/* concatinate '===' to the source to handle unpadded base64 data */
+	src = ( char * )malloc( strlen( source )+5 );
+	if ( src == NULL )
+		return -1;
+	strcpy( src, source );
+	strcat( src, "====" );
+	tmpptr = src;
+
+	/* convert as long as we get a full result */
+	while ( tmplen == 3 )
+	{
+		/* get 4 characters to convert */
+		for ( i=0; i<4; i++ )
+		{
+			/* skip invalid characters - we won't reach the end */
+			while ( *tmpptr != '=' && _base64_char_value( *tmpptr )<0 )
+				tmpptr++;
+
+			quadruple[ i ]= *( tmpptr++ );
+		}
+
+		/* convert the characters */
+		tmplen = _base64_decode_triple( quadruple, ( unsigned char* )tmpresult );
+
+		/* check if the fit in the result buffer */
+		if ( targetlen < tmplen )
+		{
+			free( src );
+			return -1;
+		}
+
+		/* put the partial result in the result buffer */
+		memcpy( target, tmpresult, tmplen );
+		target += tmplen;
+		targetlen -= tmplen;
+		converted += tmplen;
+	}
+
+	free( src );
+	return converted;
+}
+
+void test_base64(char *file) {
+	struct stat st;
+	char *fileout, *encoded, *filebuf;
+	size_t size;
+	int ret;
+	FILE *fp;
+	char *target;
+
+	stat(file, &st);
+	size = st.st_size;
+
+	fileout = (char *)malloc(strlen(file) + 1 + 4);
+	fileout[0] = 0;
+	strcat(fileout, file);
+	strcat(fileout, ".b64dec");
+
+	printf("Encoding and then decoding %s into %s, filesize is %d\n", file, fileout, (int)size);
+
+	encoded = (char *)malloc((size * 4) + 1);
+	encoded[(size * 4)] = 0;
+
+	filebuf = (char *)malloc(size);
+	fp = fopen(file, "rb");
+	fread(filebuf, size, 1, fp);
+
+	ret = base64_encode(filebuf, size, encoded, size*4);
+
+	printf("encoded len: %d\n", (int)strlen(encoded));
+
+	printf("encoded stat: %s\n", encoded);
+
+	target = (char *)malloc(size);
+
+	ret = base64_decode(encoded, target, size);
+
+	fp = fopen(fileout, "wb");
+
+	printf("fp=%p ret=%d fileout=%s\n", (void *)fp, ret, fileout);
+
+	fwrite(target, size, 1, fp);
+
+	fclose(fp);
+}

--- a/src/cc/bpfd/base64.h
+++ b/src/cc/bpfd/base64.h
@@ -1,0 +1,3 @@
+int base64_encode(unsigned char *source, size_t sourcelen, char *target, size_t targetlen);
+size_t base64_decode( char *source, unsigned char *target, size_t targetlen);
+void test_base64(char *file);

--- a/src/cc/bpfd/bpfd.c
+++ b/src/cc/bpfd/bpfd.c
@@ -1,0 +1,653 @@
+/*
+ * BPFd (Berkeley Packet Filter daemon)
+ *
+ * Copyright (C) 2017 Joel Fernandes <agnel.joel@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <linux/bpf.h>
+#include <arpa/inet.h>
+
+#include "bpfd.h"
+
+#define LINEBUF_SIZE  2000000
+#define LINE_TOKENS   10
+
+/* Command format: BPF_PROG_LOAD type prog_len license kern_version binary_data
+ *
+ * Prototype of lib call:
+ int bpf_prog_load(enum bpf_prog_type prog_type, const char *name,
+ const struct bpf_insn *insns, int prog_len,
+ const char *license, unsigned kern_version,
+ char *log_buf, unsigned log_buf_size)
+ */
+int bpf_prog_load_handle(int type, char *name, char *bin_b64, int prog_len, char *license,
+		unsigned int kern_version)
+{
+	int bin_len, ret;
+	char *bin_buf;
+	const struct bpf_insn *insns;
+
+	bin_len = strlen(bin_b64);
+	bin_buf = (char *)malloc(bin_len);
+
+	if (!base64_decode(bin_b64, bin_buf, bin_len))
+		return -1;
+
+	insns = (const struct bpf_insn *)bin_buf;
+
+	/* TODO: logging disabled for now, add mechanism in future */
+	ret = bpf_prog_load((enum bpf_prog_type)type, name, insns, prog_len,
+			(const char *)license, kern_version, 0, NULL, 0);
+
+	printf("bpf_prog_load: ret=%d\n", ret);
+	return ret;
+}
+
+int get_trace_events(char *tracefs, char *category)
+{
+	char tracef[256];
+
+	tracef[0] = 0;
+	strcat(tracef, tracefs);
+	strcat(tracef, "/events/");
+	strcat(tracef, category);
+
+	return cat_dir(tracef, 1);
+}
+
+int get_trace_events_categories(char *tracefs)
+{
+	char tracef[256];
+
+	tracef[0] = 0;
+	strcat(tracef, tracefs);
+	strcat(tracef, "/events");
+
+	return cat_dir(tracef, 1);
+}
+
+int bpf_remote_update_elem(int map_fd, char *kstr, int klen,
+		char *lstr, int llen, unsigned long flags)
+{
+	int ret = -ENOMEM;
+	void *kbin, *lbin;
+
+	kbin = (void *)malloc(klen);
+	if (!kbin)
+		goto err_update;
+
+	lbin = (void *)malloc(llen);
+	if (!lbin)
+		goto err_update;
+
+	ret = -EINVAL;
+	if (!base64_decode(kstr, kbin, klen))
+		goto err_update;
+
+	if (!base64_decode(lstr, lbin, llen))
+		goto err_update;
+
+	ret = bpf_update_elem(map_fd, kbin, lbin, flags);
+err_update:
+	if (kbin) free(kbin);
+	if (lbin) free(lbin);
+	return ret;
+}
+
+char *bpf_remote_lookup_elem(int map_fd, char *kstr, int klen, int llen)
+{
+	void *lbin, *kbin;
+	char *lstr, *rets = NULL;
+
+	kbin = (void *)malloc(klen);
+	if (!kbin)
+		goto err_update;
+
+	lbin = (void *)malloc(llen);
+	if (!lbin)
+		goto err_update;
+
+	lstr = (char *)malloc(llen * 4);
+
+	if (!lstr ||
+			!base64_decode(kstr, kbin, klen) ||
+			(bpf_lookup_elem(map_fd, kbin, lbin) < 0))
+		goto err_update;
+
+	if (base64_encode(lbin, llen, lstr, llen*4))
+		rets = (char *)lstr;
+
+err_update:
+	if (lbin) free(lbin);
+	if (kbin) free(kbin);
+	if (!rets && lstr) free(lstr);
+	return rets;
+}
+
+char *bpf_remote_get_first_key_dump_all(int map_fd, int klen, int llen)
+{
+	void *kbin, *lbin, *next_kbin = NULL, *tmp;
+	int ret, dump_buf_len = 4096, dump_used = 1;
+	char *dump_buf, *kstr, *lstr, *rets = NULL;
+
+	/* length of base64 buffer with newlines considered */
+	#define KSTR_SIZE ((klen * 2) + 2)
+	#define LSTR_SIZE ((llen * 2) + 2)
+
+	dump_buf = (char *)malloc(dump_buf_len);
+	kbin = (void *)malloc(klen);
+	lbin = (void *)malloc(llen);
+	kstr = (char *)malloc(KSTR_SIZE);
+	lstr = (char *)malloc(LSTR_SIZE);
+
+	if (!dump_buf || !kbin || !lbin || !lstr || !kstr)
+		goto err_get;
+
+	if (bpf_get_first_key(map_fd, kbin, klen) < 0)
+		goto get_done;
+
+	dump_buf[0] = 0;
+
+	do {
+		next_kbin = (void *)malloc(klen);
+		if (!next_kbin) goto err_get;
+
+		if (bpf_lookup_elem(map_fd, kbin, lbin) < 0)
+			goto err_get;
+
+		if (!base64_encode(kbin, klen, kstr, KSTR_SIZE)
+			|| !base64_encode(lbin, llen, lstr, LSTR_SIZE))
+			goto err_get;
+
+		if (dump_buf_len - dump_used < (LSTR_SIZE + KSTR_SIZE)) {
+			dump_buf_len *= 2;
+			dump_buf = (char *)realloc(dump_buf, dump_buf_len);
+		}
+
+		strcat(kstr, "\n");
+		strcat(lstr, "\n");
+		strncat(dump_buf, kstr, dump_buf_len);
+		strncat(dump_buf, lstr, dump_buf_len);
+		dump_used += (KSTR_SIZE + LSTR_SIZE);
+
+		ret = bpf_get_next_key(map_fd, kbin, next_kbin);
+
+		tmp = kbin;
+		kbin = next_kbin;
+		next_kbin = NULL;
+		free(tmp);
+	} while (ret >= 0);
+
+	rets = dump_buf;
+	goto get_done;
+
+err_get:
+	printf("bpf_remote_get_first_key_dump_all: error condition\n");
+	if (dump_buf) free(dump_buf);
+get_done:
+	if (kbin) free(kbin);
+	if (lbin) free(lbin);
+	if (kstr) free(kstr);
+	if (lstr) free(lstr);
+	if (next_kbin) free(next_kbin);
+	return rets;
+}
+
+char *bpf_remote_get_first_key(int map_fd, int klen)
+{
+	void *kbin;
+	char *kstr, *rets = NULL;
+
+	kbin = (void *)malloc(klen);
+	if (!kbin)
+		goto err_get;
+
+	kstr = (char *)malloc(klen * 4);
+	if (!kstr || bpf_get_first_key(map_fd, kbin, klen) < 0)
+		goto err_get;
+
+	if (base64_encode(kbin, klen, kstr, klen*4))
+		rets = kstr;
+err_get:
+	if (kbin) free(kbin);
+	if (!rets && kstr) free(kstr);
+	return rets;
+}
+
+char *bpf_remote_get_next_key(int map_fd, char *kstr, int klen)
+{
+	void *kbin, *next_kbin;
+	char *next_kstr, *rets = NULL;
+
+	kbin = (void *)malloc(klen);
+	if (!kbin)
+		goto err_update;
+
+	next_kbin = (void *)malloc(klen);
+	if (!next_kbin)
+		goto err_update;
+
+	next_kstr = (char *)malloc(klen * 4);
+
+	if (!next_kstr ||
+			!base64_decode(kstr, kbin, klen) ||
+			(bpf_get_next_key(map_fd, kbin, next_kbin) < 0))
+		goto err_update;
+
+	if (base64_encode(next_kbin, klen, next_kstr, klen*4))
+		rets = (char *)next_kstr;
+
+err_update:
+	if (kbin) free(kbin);
+	if (next_kbin) free(next_kbin);
+	if (!rets && next_kstr) free(next_kstr);
+	return rets;
+}
+
+int bpf_remote_delete_elem(int map_fd, char *kstr, int klen)
+{
+	void *kbin;
+	int ret = -ENOMEM;
+
+	kbin = (void *)malloc(klen);
+	if (!kbin)
+		goto err_update;
+
+	ret = -1;
+	if (!base64_decode(kstr, kbin, klen))
+		goto err_update;
+
+	ret = bpf_delete_elem(map_fd, kbin);
+
+err_update:
+	if (kbin) free(kbin);
+	return ret;
+}
+
+/*
+ * Clear a map by iterating over keys.
+ * Return delete error code if any deletes or allocs fail
+ * else return how many keys were iterated and deleted.
+ */
+int bpf_clear_map(int map_fd, int klen)
+{
+	void *kbin, *next_kbin = NULL, *tmp = NULL;
+	int count = 0, ret = -ENOMEM;
+
+	kbin = (void *)malloc(klen);
+	if (!kbin)
+		goto err_clear;
+
+	if (bpf_get_first_key(map_fd, kbin, klen) < 0) {
+		ret = 0;
+		goto err_clear;
+	}
+
+	do {
+		next_kbin = (void *)malloc(klen);
+		if (!next_kbin) {
+			ret = -ENOMEM;
+			goto err_clear;
+		}
+
+		ret = bpf_delete_elem(map_fd, kbin);
+		if (ret < 0)
+			goto err_clear;
+		count++;
+
+		ret = bpf_get_next_key(map_fd, kbin, next_kbin);
+
+		tmp = kbin;
+		kbin = next_kbin;
+		next_kbin = NULL;
+		free(tmp);
+	} while (ret >= 0);
+
+	ret = count;
+err_clear:
+	if (kbin) free(kbin);
+	if (next_kbin) free(next_kbin);
+	return ret;
+}
+
+int main(int argc, char **argv)
+{
+	char line_buf[LINEBUF_SIZE];
+	char *cmd, *lineptr, *argstr, *tok, *kvers_str = NULL;
+	int len, c, kvers = -1;
+
+	opterr = 0;
+	while ((c = getopt (argc, argv, "k:")) != -1)
+		switch (c)
+		{
+			case 'k':
+				kvers_str = optarg;
+				break;
+			case '?':
+				if (optopt == 'k')
+					fprintf(stderr, "Option -%c requires an argument.\n", optopt);
+				else if (isprint (optopt))
+					fprintf(stderr, "Unknown option `-%c'.\n", optopt);
+				else
+					fprintf(stderr,"Unknown option character `\\x%x'.\n", optopt);
+				return 1;
+			default:
+				abort();
+		}
+
+	if (kvers_str)
+		kvers = atoi(kvers_str);
+
+	printf("STARTED_BPFD\n");
+
+	while (fgets(line_buf, LINEBUF_SIZE, stdin)) {
+		line_buf[strcspn(line_buf, "\r\n")] = 0;
+		line_buf[strcspn(line_buf, "\n")] = 0;
+
+		lineptr = line_buf;
+		len = strlen(lineptr);
+
+		/* Empty input */
+		if (!len)
+			continue;
+
+		if (!strcmp(lineptr, "exit"))
+			break;
+
+		/* Command parsing logic */
+		cmd = strtok(lineptr, " ");
+
+		if (!cmd)
+			break;
+
+		/* No "command args" format found */
+		if (strlen(cmd) == len)
+			cmd = NULL;
+
+		if (cmd) {
+			lineptr = line_buf;
+			while (*lineptr)
+				lineptr++;
+			lineptr++;
+
+			if (!*lineptr) {
+				cmd = NULL;
+			} else {
+				argstr = lineptr;
+			}
+		}
+
+		printf("START_BPFD_OUTPUT\n");
+		fflush(stdout);
+
+		if (!cmd)
+			goto invalid_command;
+
+		if (!strcmp(cmd, "GET_AVAIL_FILTER_FUNCS")) {
+
+			if (cat_tracefs_file(argstr, "available_filter_functions") < 0)
+				goto invalid_command;
+
+		} else if (!strcmp(cmd, "GET_KPROBES_BLACKLIST")) {
+
+			if (cat_tracefs_file(argstr, "../kprobes/blacklist") < 0)
+				goto invalid_command;
+
+		} else if (!strcmp(cmd, "GET_TRACE_EVENTS_CATEGORIES")) {
+
+			if (get_trace_events_categories(argstr) < 0)
+				goto invalid_command;
+	
+		} else if (!strcmp(cmd, "GET_TRACE_EVENTS")) {
+			int len;
+			char *category, *tracefs;
+
+			PARSE_FIRST_STR(tracefs);
+			PARSE_STR(category);
+
+			if (get_trace_events(tracefs, category) < 0)
+				goto invalid_command;
+
+		} else if (!strcmp(cmd, "BPF_PROG_LOAD")) {
+
+			int len, prog_len, type;
+			char *license, *bin_data, *name;
+			unsigned int kern_version, kvdummy;
+			/*
+			 * Command format: BPF_PROG_LOAD type prog_len license kern_version binary_data
+			 * Prototype of lib call:
+			 * int bpf_prog_load(enum bpf_prog_type prog_type,
+			 * const struct bpf_insn *insns, int prog_len,
+			 * const char *license, unsigned kern_version, char *log_buf, unsigned log_buf_size)
+			*/
+			PARSE_FIRST_INT(type);
+			PARSE_STR(name);
+			PARSE_INT(prog_len);
+			PARSE_STR(license);
+			if (kvers != -1) {
+				kern_version = kvers;
+				PARSE_UINT(kvdummy);  /* skip field */
+			} else {
+				PARSE_UINT(kern_version);
+			}
+			PARSE_STR(bin_data);
+
+			if (!strcmp(name, "__none__"))
+				name = NULL;
+			bpf_prog_load_handle(type, name, bin_data, prog_len, license, kern_version);
+
+		} else if (!strcmp(cmd, "BPF_ATTACH_KPROBE")) {
+			int len, ret, prog_fd, type;
+			char *ev_name, *fn_name;
+
+			PARSE_FIRST_INT(prog_fd);
+			PARSE_INT(type);
+			PARSE_STR(ev_name);
+			PARSE_STR(fn_name);
+
+			/*
+			 * TODO: We're leaking a struct perf_reader here, we should free it somewhere.
+			 */
+			if (!bpf_attach_kprobe(prog_fd, type, ev_name, fn_name, NULL, NULL))
+				ret = -1;
+			else
+				ret = prog_fd;
+
+			printf("bpf_attach_kprobe: ret=%d\n", ret);
+
+		} else if (!strcmp(cmd, "BPF_DETACH_KPROBE")) {
+			int len, ret;
+			char *evname;
+
+			PARSE_FIRST_STR(evname);
+			ret = bpf_detach_kprobe(evname);
+			printf("bpf_detach_kprobe: ret=%d\n", ret);
+
+		} else if (!strcmp(cmd, "BPF_ATTACH_TRACEPOINT")) {
+			int len, ret, prog_fd;
+			char *tpname, *category;
+			/*
+			 * void * bpf_attach_tracepoint(int progfd, const char *tp_category,
+			 *		const char *tp_name, perf_reader_cb cb, void *cb_cookie)
+			 */
+
+			PARSE_FIRST_INT(prog_fd);
+			PARSE_STR(category);
+			PARSE_STR(tpname);
+
+			/*
+			 * TODO: We're leaking a struct perf_reader here, we should free it somewhere.
+			 */
+			if (!bpf_attach_tracepoint(prog_fd, category, tpname, NULL, NULL))
+				ret = -1;
+			else
+				ret = prog_fd;
+
+			printf("bpf_attach_tracepoint: ret=%d\n", ret);
+
+		} else if (!strcmp(cmd, "BPF_CREATE_MAP")) {
+			/*
+				int bpf_create_map(enum bpf_map_type map_type, const char *name,
+                   int key_size, int value_size, int max_entries,
+                   int map_flags);
+			 */
+
+			int ret, type, len, key_size, value_size, max_entries, map_flags;
+			char *name;
+
+			PARSE_FIRST_INT(type);
+			PARSE_STR(name);
+			PARSE_INT(key_size);
+			PARSE_INT(value_size);
+			PARSE_INT(max_entries);
+			PARSE_INT(map_flags);
+
+			if (!strcmp(name, "__none__"))
+				name = NULL;
+			ret = bpf_create_map((enum bpf_map_type)type, name, key_size, value_size, max_entries, map_flags);
+			printf("bpf_create_map: ret=%d\n", ret);
+
+		} else if (!strcmp(cmd, "BPF_OPEN_PERF_BUFFER")) {
+			int pid, cpu, page_cnt, ret;
+
+			PARSE_FIRST_INT(pid);
+			PARSE_INT(cpu);
+			PARSE_INT(page_cnt);
+
+			ret = bpf_remote_open_perf_buffer(pid, cpu, page_cnt);
+			printf("bpf_open_perf_buffer: ret=%d\n", ret);
+
+		} else if (!strcmp(cmd, "BPF_UPDATE_ELEM")) {
+			int map_fd, klen, llen, ret;
+			unsigned long long flags;
+			char *tok, *kstr, *lstr;
+
+			PARSE_FIRST_INT(map_fd);
+			PARSE_STR(kstr);
+			PARSE_INT(klen);
+			PARSE_STR(lstr);
+			PARSE_INT(llen);
+			PARSE_ULL(flags);
+
+			ret = bpf_remote_update_elem(map_fd, kstr, klen, lstr, llen, flags);
+			printf("bpf_update_elem: ret=%d\n", ret);
+
+		} else if (!strcmp(cmd, "BPF_LOOKUP_ELEM")) {
+			int map_fd, klen, llen;
+			char *tok, *kstr, *lstr;
+
+			PARSE_FIRST_INT(map_fd);
+			PARSE_STR(kstr);
+			PARSE_INT(klen);
+			PARSE_INT(llen);
+
+			lstr = bpf_remote_lookup_elem(map_fd, kstr, klen, llen);
+			if (!lstr)
+				printf("bpf_lookup_elem: ret=%d\n", -1);
+			else
+				printf("%s\n", lstr);
+			if (lstr) free(lstr);
+
+		} else if (!strcmp(cmd, "BPF_GET_FIRST_KEY")) {
+			int map_fd, klen, llen, dump_all;
+			char *tok, *kstr;
+
+			PARSE_FIRST_INT(map_fd);
+			PARSE_INT(klen);
+			PARSE_INT(llen);
+			PARSE_INT(dump_all);
+
+			if (dump_all)
+				kstr = bpf_remote_get_first_key_dump_all(map_fd, klen, llen);
+			else
+				kstr = bpf_remote_get_first_key(map_fd, klen);
+
+			if (!kstr)
+				printf("bpf_get_first_key: ret=%d\n", -1);
+			else
+				printf("%s\n", kstr);
+			if (kstr) free(kstr);
+
+		} else if (!strcmp(cmd, "BPF_GET_NEXT_KEY")) {
+			int map_fd, klen;
+			char *tok, *kstr, *next_kstr;
+
+			PARSE_FIRST_INT(map_fd);
+			PARSE_STR(kstr);
+			PARSE_INT(klen);
+
+			next_kstr = bpf_remote_get_next_key(map_fd, kstr, klen);
+			if (!next_kstr)
+				printf("bpf_get_next_key: ret=%d\n", -1);
+			else
+				printf("%s\n", next_kstr);
+			if (next_kstr) free(next_kstr);
+
+		} else if (!strcmp(cmd, "BPF_DELETE_ELEM")) {
+			int map_fd, klen, ret;
+			char *tok, *kstr;
+
+			PARSE_FIRST_INT(map_fd);
+			PARSE_STR(kstr);
+			PARSE_INT(klen);
+
+			ret = bpf_remote_delete_elem(map_fd, kstr, klen);
+			printf("bpf_delete_elem: ret=%d\n", ret);
+
+		} else if (!strcmp(cmd, "BPF_CLEAR_MAP")) {
+			int map_fd, klen, ret;
+
+			PARSE_FIRST_INT(map_fd);
+			PARSE_INT(klen);
+
+			ret = bpf_clear_map(map_fd, klen);
+			printf("bpf_clear_map: ret=%d\n", ret);
+
+		} else if (!strcmp(cmd, "PERF_READER_POLL")) {
+			int len, *fds, i, timeout, ret;
+
+			PARSE_FIRST_INT(timeout);
+			PARSE_INT(len);
+
+			fds = (void *)malloc(len);
+			if (!fds)
+				printf("perf_reader_poll: ret=%d\n", -ENOMEM);
+
+			for (i = 0; i < len; i++) {
+				PARSE_INT(fds[i]);
+			}
+
+			ret = remote_perf_reader_poll(fds, len, timeout);
+			if (ret < 0)
+				printf("perf_reader_poll: ret=%d\n", ret);
+		} else {
+
+invalid_command:
+			printf("Command not recognized\n");
+		}
+
+		printf("END_BPFD_OUTPUT\n");
+		fflush(stdout);
+	}
+	return 0;
+}

--- a/src/cc/bpfd/bpfd.h
+++ b/src/cc/bpfd/bpfd.h
@@ -1,0 +1,72 @@
+/*
+ * BPFd (Berkeley Packet Filter daemon)
+ * This header is only supposed to be used by bpfd.c
+ *
+ * Copyright (C) 2017 Joel Fernandes <agnel.joel@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "utils.h"
+#include "libbpf.h"
+#include "base64.h"
+
+#define PARSE_INT(var)				\
+	tok = strtok(NULL, " ");		\
+	if (!tok)				\
+		goto invalid_command;		\
+	if (!sscanf(tok, "%d ", &var))		\
+		goto invalid_command;
+
+#define PARSE_UINT(var)				\
+	tok = strtok(NULL, " ");		\
+	if (!tok)				\
+		goto invalid_command;		\
+	if (!sscanf(tok, "%u ", &var))		\
+		goto invalid_command;
+
+#define PARSE_ULL(var)				\
+	tok = strtok(NULL, " ");		\
+	if (!tok)				\
+		goto invalid_command;		\
+	if (!sscanf(tok, "%llu ", &var))		\
+		goto invalid_command;
+
+#define PARSE_STR(var)				\
+	tok = strtok(NULL, " ");		\
+	if (!tok)				\
+		goto invalid_command;		\
+	var = tok;
+
+#define PARSE_FIRST_TOK				\
+	len = strlen(argstr);			\
+	tok = strtok(argstr, " ");		\
+	if (strlen(tok) == len)			\
+		goto invalid_command;
+
+#define PARSE_FIRST_INT(var)		\
+	PARSE_FIRST_TOK					\
+	if (!sscanf(tok, "%d ", &var))	\
+		goto invalid_command;
+
+#define PARSE_FIRST_UINT(var)		\
+	PARSE_FIRST_TOK					\
+	if (!sscanf(tok, "%u ", &var))	\
+		goto invalid_command;
+
+#define PARSE_FIRST_STR(var)		\
+	PARSE_FIRST_TOK					\
+	var = tok;
+
+int bpf_remote_open_perf_buffer(int pid, int cpu, int page_cnt);
+int remote_perf_reader_poll(int *fds, int len, int timeout);

--- a/src/cc/bpfd/remote_perf_reader.c
+++ b/src/cc/bpfd/remote_perf_reader.c
@@ -1,0 +1,106 @@
+/*
+ * BPFd (Berkeley Packet Filter daemon)
+ * Support for perf readers.
+ *
+ * Copyright (C) 2017 Joel Fernandes <agnel.joel@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This file's functionality should be properly abstracted
+ * within libbpf.c and perf_reader.c. For now, duplicate the
+ * struct here
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <linux/bpf.h>
+#include <arpa/inet.h>
+#include "perf_reader.h"
+#include "bpfd.h"
+
+#define MAX_READERS 1024
+
+struct perf_reader {
+  perf_reader_cb cb;
+  perf_reader_raw_cb raw_cb;
+  perf_reader_lost_cb lost_cb;
+  void *cb_cookie; // to be returned in the cb
+  void *buf; // for keeping segmented data
+  size_t buf_size;
+  void *base;
+  int page_size;
+  int page_cnt;
+  int fd;
+  uint32_t type;
+  uint64_t sample_type;
+};
+
+struct perf_reader *remote_readers[MAX_READERS];
+
+void remote_raw_reader_cb(void *cookie, void *raw, int size)
+{
+	struct perf_reader *reader = cookie;
+	char *raw_str;
+
+	raw_str = malloc(size * 4);
+
+	if (!base64_encode(raw, size, raw_str, size*4))
+		printf("raw_cb: b64 encode failed for reader fd=%d\n",
+			   reader->fd);
+
+	printf("%d %d %s\n", reader->fd, size, raw_str);
+
+	free(raw_str);
+}
+
+void remote_lost_reader_cb(void *ptr, uint64_t lost)
+{
+}
+
+int bpf_remote_open_perf_buffer(int pid, int cpu, int page_cnt)
+{
+	struct perf_reader *reader;
+
+	reader = bpf_open_perf_buffer(remote_raw_reader_cb, remote_lost_reader_cb,
+								  NULL, pid, cpu, page_cnt);
+	if (!reader)
+		return -1;
+
+	reader->cb_cookie = reader;
+	remote_readers[reader->fd] = reader;
+	return reader->fd;
+}
+
+int remote_perf_reader_poll(int *fds, int len, int timeout)
+{
+	struct perf_reader **readers;
+	int i, ret;
+
+	readers = (struct perf_reader **)malloc(len * sizeof(void *));
+
+	for (i = 0; i < len; i++)
+		readers[i] = remote_readers[fds[i]];
+
+	ret = perf_reader_poll(len, readers, timeout);
+
+	free(readers);
+
+	return ret;
+}

--- a/src/cc/bpfd/utils.c
+++ b/src/cc/bpfd/utils.c
@@ -1,0 +1,90 @@
+/*
+ * BPFd (Berkeley Packet Filter daemon)
+ * Common utility/helper functions.
+ *
+ * Copyright (C) 2017 Joel Fernandes <agnel.joel@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+#include "utils.h"
+#include <dirent.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+
+/* Read a file on the local fs to stdout */
+int cat_file(char *path) {
+	char buf[4096];
+	int len, fd;
+
+	fd = open(path, O_RDONLY);
+	if (fd < 0) {
+		printf("Open failed, ignoring\n");
+		return fd;
+	}
+
+	while ((len = read(fd, &buf, 4096)) > 0)
+		write(1, buf, len);
+
+	close(fd);
+
+	return 0;
+
+}
+
+/* Read a tracefs file to stdout */
+int cat_tracefs_file(char *tracefs, char *fn) {
+	char tracef[100];
+
+	tracef[0] = 0;
+	strcat(tracef, tracefs);
+	strcat(tracef, "/");
+	strcat(tracef, fn);
+
+	return cat_file(tracef);
+}
+
+int cat_dir(char *path, int dirs_only)
+{
+	DIR *dp;
+	struct dirent *ep;
+
+	dp = opendir(path);
+	if (!dp)
+		return -1;
+
+	while (ep = readdir(dp)) {
+		struct stat st;
+
+		if (strcmp(ep->d_name, ".") == 0 || strcmp(ep->d_name, "..") == 0)
+			continue;
+
+		if (dirs_only) {
+			if (fstatat(dirfd(dp), ep->d_name, &st, 0) < 0)
+				continue;
+
+			if (!S_ISDIR(st.st_mode))
+				continue;
+		}
+
+		printf("%s\n", ep->d_name);
+	}
+	closedir (dp);
+
+	return 0;
+}

--- a/src/cc/bpfd/utils.h
+++ b/src/cc/bpfd/utils.h
@@ -1,0 +1,22 @@
+/*
+ * BPFd (Berkeley Packet Filter daemon)
+ * Common utility/helper functions.
+ *
+ * Copyright (C) 2017 Joel Fernandes <agnel.joel@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+int cat_file(char *path);
+int cat_tracefs_file(char *tracefs, char *fn);
+int cat_dir(char *path, int dirs_only);

--- a/tests/python/CMakeLists.txt
+++ b/tests/python/CMakeLists.txt
@@ -66,6 +66,8 @@ add_test(NAME py_test_dump_func WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMAND ${TEST_WRAPPER} py_dump_func simple ${CMAKE_CURRENT_SOURCE_DIR}/test_dump_func.py)
 add_test(NAME py_test_tools_smoke WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMAND ${TEST_WRAPPER} py_test_tools_smoke sudo ${CMAKE_CURRENT_SOURCE_DIR}/test_tools_smoke.py)
+add_test(NAME py_test_tools_on_remote WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  COMMAND ${TEST_WRAPPER} py_test_tools_on_remote sudo ${CMAKE_CURRENT_SOURCE_DIR}/test_tools_on_remote.py)
 add_test(NAME py_test_tools_memleak WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMAND ${TEST_WRAPPER} py_test_tools_memleak sudo ${CMAKE_CURRENT_SOURCE_DIR}/test_tools_memleak.py)
 add_test(NAME py_test_usdt WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}

--- a/tests/python/test_tools_on_remote.py
+++ b/tests/python/test_tools_on_remote.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+# Copyright (c) Jazel Canseco, 2018
+# Licensed under the Apache License, Version 2.0 (the "License")
+
+import os
+import subprocess
+
+from unittest import main, skipUnless, TestCase
+from test_tools_smoke import ToolTestRunner
+
+class RemoteTests(TestCase, ToolTestRunner):
+
+    def setUp(self):
+        self.set_up_env_to_run_tools_on_remote()
+
+    def set_up_env_to_run_tools_on_remote(self):
+        bpfd_dir = "../../build/src/cc/bpfd"
+        os.environ["PATH"] += os.pathsep + bpfd_dir
+
+        os.environ["ARCH"] = "x86"
+        os.environ["BCC_REMOTE"] = "shell"
+
+    def test_biolatency(self):
+        self.run_with_duration("biolatency.py 1 1")
+
+    def test_filetop(self):
+        self.run_with_duration("filetop.py 1 1")
+
+    def test_hardirqs(self):
+        self.run_with_duration("hardirqs.py 1 1")
+
+    def test_opensnoop(self):
+        self.run_with_int("opensnoop.py")
+
+if __name__ == "__main__":
+    main()

--- a/tests/python/test_tools_smoke.py
+++ b/tests/python/test_tools_smoke.py
@@ -21,8 +21,7 @@ def kernel_version_ge(major, minor):
         return False
     return True
 
-@skipUnless(kernel_version_ge(4,1), "requires kernel >= 4.1")
-class SmokeTests(TestCase):
+class ToolTestRunner(object):
     # Use this for commands that have a built-in timeout, so they only need
     # to be killed in case of a hard hang.
     def run_with_duration(self, command, timeout=10):
@@ -51,6 +50,8 @@ class SmokeTests(TestCase):
         self.assertTrue((rc == 0 and allow_early) or rc == 124
                         or (rc == 137 and kill), "rc was %d" % rc)
 
+@skipUnless(kernel_version_ge(4,1), "requires kernel >= 4.1")
+class SmokeTests(TestCase, ToolTestRunner):
     def kmod_loaded(self, mod):
         mods = open("/proc/modules", "r")
         reg = re.compile("^%s\s" % mod)


### PR DESCRIPTION
This introduces tests similar to the ones in test_tools_smoke.py. The difference
is that instead of running the tools locally, these tests run them on a
remote target (in this case, a shell process) via BPFd to ensure that they are
able to run without issues.

Signed-off-by: Jazel Canseco <jcanseco@google.com>