### PR TITLE
Implement kernel and userspace symbol lookup for remote targets via BPFd

### DIFF
--- a/src/cc/bpfd/CMakeLists.txt
+++ b/src/cc/bpfd/CMakeLists.txt
@@ -3,3 +3,4 @@
 
 add_executable(bpfd bpfd.c base64.c remote_perf_reader.c utils.c)
 target_link_libraries(bpfd bpf-static)
+target_link_libraries(bpfd bcc-static)

--- a/src/cc/bpfd/bpfd.c
+++ b/src/cc/bpfd/bpfd.c
@@ -28,9 +28,18 @@
 #include <arpa/inet.h>
 
 #include "bpfd.h"
+#include "bcc_syms.h"
 
 #define LINEBUF_SIZE  2000000
 #define LINE_TOKENS   10
+
+#define DEFAULT_MAX_PID  32768
+
+struct usym_cache {
+	int pid;
+	char *exe_path;
+	void *cache;
+};
 
 /* Command format: BPF_PROG_LOAD type prog_len license kern_version binary_data
  *
@@ -330,11 +339,69 @@ err_clear:
 	return ret;
 }
 
+char *get_pid_exe(int pid)
+{
+	const int PATHBUF_SIZE = 4096;
+
+	char *exe_path = (char *)malloc(PATHBUF_SIZE);
+	char exe_link[PATHBUF_SIZE];
+	int num_chars_read = 0;
+
+	snprintf(exe_link, PATHBUF_SIZE, "/proc/%d/exe", pid);
+	num_chars_read = readlink(exe_link, exe_path, PATHBUF_SIZE);
+	if (num_chars_read < 0)
+		num_chars_read = 0;
+	exe_path[num_chars_read] = '\0';
+	return exe_path;
+}
+
+struct usym_cache *get_or_set_usym_cache(int pid, struct usym_cache *usym_caches[])
+{
+	struct usym_cache *usym_cache = usym_caches[pid % DEFAULT_MAX_PID];
+
+	char *exe_path = get_pid_exe(pid);
+	if (!usym_cache || usym_cache->pid != pid || strcmp(usym_cache->exe_path, exe_path)) {
+		if (!usym_cache) {
+			usym_cache = (struct usym_cache *)malloc(sizeof(struct usym_cache));
+		} else {
+			free(usym_cache->exe_path);
+			bcc_free_symcache(usym_cache->cache, usym_cache->pid);
+		}
+
+		usym_cache->pid = pid;
+		usym_cache->exe_path = exe_path;
+		usym_cache->cache = bcc_symcache_new(pid, NULL);
+
+		usym_caches[pid % DEFAULT_MAX_PID] = usym_cache;
+	} else {
+		free(exe_path);
+	}
+
+	return usym_cache;
+}
+
+void free_usym_caches(struct usym_cache **usym_caches)
+{
+	int i;
+	for (i = 0; i < DEFAULT_MAX_PID; i++) {
+		if (usym_caches[i]) {
+			free(usym_caches[i]->exe_path);
+			bcc_free_symcache(usym_caches[i]->cache, usym_caches[i]->pid);
+
+			free(usym_caches[i]);
+		}
+	}
+
+	free(usym_caches);
+}
+
 int main(int argc, char **argv)
 {
 	char line_buf[LINEBUF_SIZE];
 	char *cmd, *lineptr, *argstr, *tok, *kvers_str = NULL;
 	int len, c, kvers = -1;
+	void *ksym_cache = NULL;
+	struct usym_cache **usym_caches = (struct usym_cache **)calloc(DEFAULT_MAX_PID, sizeof(struct usym_cache *));
 
 	opterr = 0;
 	while ((c = getopt (argc, argv, "k:")) != -1)
@@ -417,7 +484,7 @@ int main(int argc, char **argv)
 
 			if (get_trace_events_categories(argstr) < 0)
 				goto invalid_command;
-	
+
 		} else if (!strcmp(cmd, "GET_TRACE_EVENTS")) {
 			int len;
 			char *category, *tracefs;
@@ -670,6 +737,78 @@ int main(int argc, char **argv)
 			ret = remote_perf_reader_poll(fds, len, timeout);
 			if (ret < 0)
 				printf("perf_reader_poll: ret=%d\n", ret);
+		} else if (!strcmp(cmd, "GET_KSYM_NAME")) {
+			int len, ret;
+			uint64_t addr;
+			struct bcc_symbol sym;
+
+			PARSE_FIRST_UINT64(addr);
+
+			if(!ksym_cache)
+				ksym_cache = bcc_symcache_new(-1, NULL);
+
+			ret = bcc_symcache_resolve_no_demangle(ksym_cache, addr, &sym);
+			printf("GET_KSYM_NAME: ret=%d\n", ret);
+			if (!ret)
+				printf("%s;%"PRIu64";%s\n", sym.name, sym.offset, sym.module);
+		} else if (!strcmp(cmd, "GET_KSYM_ADDR")) {
+			int len, ret;
+			char* name;
+			uint64_t addr;
+
+			PARSE_FIRST_STR(name);
+
+			if(!ksym_cache)
+				ksym_cache = bcc_symcache_new(-1, NULL);
+
+			ret = bcc_symcache_resolve_name(ksym_cache, NULL, name, &addr);
+			printf("GET_KSYM_ADDR: ret=%d\n", ret);
+			if (!ret)
+				printf("%"PRIu64"\n", addr);
+		} else if (!strcmp(cmd, "GET_USYM_NAME")) {
+			int len, ret, pid, demangle;
+			uint64_t addr;
+			struct bcc_symbol sym;
+			const char *name;
+			struct usym_cache *usym_cache = NULL;
+
+			PARSE_FIRST_INT(pid);
+			PARSE_UINT64(addr);
+			PARSE_INT(demangle);
+
+			usym_cache = get_or_set_usym_cache(pid, usym_caches);
+
+			if (demangle)
+				ret = bcc_symcache_resolve(usym_cache->cache, addr, &sym);
+			else
+				ret = bcc_symcache_resolve_no_demangle(usym_cache->cache, addr, &sym);
+
+			printf("GET_USYM_NAME: ret=%d\n", ret);
+			if (!ret) {
+				if (demangle)
+					name = sym.demangle_name;
+				else
+					name = sym.name;
+				printf("%s;%"PRIu64";%s\n", name, sym.offset, sym.module);
+			}
+			bcc_symbol_free_demangle_name(&sym);
+		} else if (!strcmp(cmd, "GET_USYM_ADDR")) {
+			int len, ret, pid;
+			char *name;
+			char *module;
+			uint64_t addr;
+			struct usym_cache *usym_cache = NULL;
+
+			PARSE_FIRST_INT(pid);
+			PARSE_STR(name);
+			PARSE_STR(module);
+
+			usym_cache = get_or_set_usym_cache(pid, usym_caches);
+
+			ret = bcc_symcache_resolve_name(usym_cache->cache, module, name, &addr);
+			printf("GET_USYM_ADDR: ret=%d\n", ret);
+			if (!ret)
+				printf("%"PRIu64"\n", addr);
 		} else {
 
 invalid_command:
@@ -679,5 +818,6 @@ invalid_command:
 		printf("END_BPFD_OUTPUT\n");
 		fflush(stdout);
 	}
+	free_usym_caches(usym_caches);
 	return 0;
 }

--- a/src/cc/bpfd/bpfd.h
+++ b/src/cc/bpfd/bpfd.h
@@ -20,8 +20,8 @@
 #include <inttypes.h>
 
 #include "utils.h"
-#include "libbpf.h"
 #include "base64.h"
+#include "libbpf.h"
 
 #define PARSE_INT(var)				\
 	tok = strtok(NULL, " ");		\
@@ -71,6 +71,11 @@
 #define PARSE_FIRST_UINT(var)		\
 	PARSE_FIRST_TOK					\
 	if (!sscanf(tok, "%u ", &var))	\
+		goto invalid_command;
+
+#define PARSE_FIRST_UINT64(var)		\
+	PARSE_FIRST_TOK					\
+	if (!sscanf(tok, "%"SCNu64" ", &var))	\
 		goto invalid_command;
 
 #define PARSE_FIRST_STR(var)		\

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -748,7 +748,7 @@ class BPF(object):
         """
         libr = libremote.LibRemote(remote)
         ret = BPF.get_tracepoints_libremote(tp_re, libr)
-        self.libremote.close_connection()
+        libr.close_connection()
         return ret
 
     @staticmethod

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -1185,7 +1185,10 @@ class BPF(object):
         Example output when both show_module and show_offset are False:
             "start_thread"
         """
-        name, offset, module = BPF._sym_cache(pid).resolve(addr, demangle)
+        if BPF._libremote and pid == -1:
+            name, offset, module = BPF._libremote.ksym(addr)
+        else:
+            name, offset, module = BPF._sym_cache(pid).resolve(addr, demangle)
         offset = "+0x%x" % offset if show_offset and name is not None else ""
         name = name or "[unknown]"
         name = name + offset
@@ -1213,7 +1216,10 @@ class BPF(object):
 
         Translate a kernel name into an address. This is the reverse of
         ksym. Returns -1 when the function name is unknown."""
-        return BPF._sym_cache(-1).resolve_name(None, name)
+        if BPF._libremote:
+            return BPF._libremote.ksymname(name)
+        else:
+            return BPF._sym_cache(-1).resolve_name(None, name)
 
     def num_open_kprobes(self):
         """num_open_kprobes()

--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -1185,8 +1185,8 @@ class BPF(object):
         Example output when both show_module and show_offset are False:
             "start_thread"
         """
-        if BPF._libremote and pid == -1:
-            name, offset, module = BPF._libremote.ksym(addr)
+        if BPF._libremote:
+            name, offset, module = BPF._libremote.sym(pid, addr, demangle)
         else:
             name, offset, module = BPF._sym_cache(pid).resolve(addr, demangle)
         offset = "+0x%x" % offset if show_offset and name is not None else ""

--- a/src/python/bcc/remote/libremote.py
+++ b/src/python/bcc/remote/libremote.py
@@ -248,6 +248,28 @@ class LibRemote(object):
             # TODO: implement lost cbs too
             raw_cb(ct.cast(id(self), ct.py_object), data_bin, ct.c_int(size))
 
+    def ksym(self, addr):
+        cmd = "GET_KSYM_NAME {} 0".format(addr)
+        ret = self._remote_send_command(cmd)
+
+        ret_code = ret[0]
+        if ret_code < 0:
+            return None, addr, None
+        else:
+            name, offset, module = ret[1][1].split(";")
+            return name, offset, module
+
+    def ksymname(self, name):
+        cmd = "GET_KSYM_ADDR {} 0".format(name)
+        ret = self._remote_send_command(cmd)
+
+        ret_code = ret[0]
+        if ret_code < 0:
+            return -1
+        else:
+            addr = ret[1][1]
+            return addr
+
     def close_connection(self):
         self._remote_send_command("exit")
         self.remote.close_connection()

--- a/src/python/bcc/remote/libremote.py
+++ b/src/python/bcc/remote/libremote.py
@@ -248,6 +248,12 @@ class LibRemote(object):
             # TODO: implement lost cbs too
             raw_cb(ct.cast(id(self), ct.py_object), data_bin, ct.c_int(size))
 
+    def sym(self, pid, addr, demangle=True):
+        if pid < 0:
+            return self.ksym(addr)
+        else:
+            return self.usym(pid, addr, demangle)
+
     def ksym(self, addr):
         cmd = "GET_KSYM_NAME {} 0".format(addr)
         ret = self._remote_send_command(cmd)
@@ -261,6 +267,28 @@ class LibRemote(object):
 
     def ksymname(self, name):
         cmd = "GET_KSYM_ADDR {} 0".format(name)
+        ret = self._remote_send_command(cmd)
+
+        ret_code = ret[0]
+        if ret_code < 0:
+            return -1
+        else:
+            addr = ret[1][1]
+            return addr
+
+    def usym(self, pid, addr, demangle=True):
+        cmd = "GET_USYM_NAME {} {} {}".format(pid, addr, 1 if demangle else 0)
+        ret = self._remote_send_command(cmd)
+
+        ret_code = ret[0]
+        if ret_code < 0:
+            return None, addr, None
+        else:
+            name, offset, module = ret[1][1].split(";")
+            return name, offset, module
+
+    def usymname(self, pid, name, module):
+        cmd = "GET_USYM_ADDR {} {} {}".format(pid, name, module)
         ret = self._remote_send_command(cmd)
 
         ret_code = ret[0]

--- a/tests/python/test_tools_on_remote.py
+++ b/tests/python/test_tools_on_remote.py
@@ -23,14 +23,23 @@ class RemoteTests(TestCase, ToolTestRunner):
     def test_biolatency(self):
         self.run_with_duration("biolatency.py 1 1")
 
+    def test_cachestat(self):
+        self.run_with_duration("cachestat.py 1 1")
+
     def test_filetop(self):
         self.run_with_duration("filetop.py 1 1")
 
     def test_hardirqs(self):
         self.run_with_duration("hardirqs.py 1 1")
 
+    def test_offcputime(self):
+        self.run_with_duration("offcputime.py 1")
+
     def test_opensnoop(self):
         self.run_with_int("opensnoop.py")
+
+    def test_stackcount(self):
+        self.run_with_int("stackcount.py __kmalloc -i 1")
 
 if __name__ == "__main__":
     main()

--- a/tools/cachestat.py
+++ b/tools/cachestat.py
@@ -21,7 +21,6 @@ from bcc import BPF
 from time import sleep, strftime
 import signal
 import re
-import os
 from sys import argv
 
 # signal handler
@@ -137,22 +136,6 @@ while 1:
 
         ksym = b.ksym(k.ip)
 
-        if "BAD_HIKEY_DEMO_HACK" in os.environ:
-            badhh = True
-        else:
-            badhh = False
-
-        if badhh:
-            ksym = "{}".format(hex(k.ip))
-            if ksym == "0xffffff80081dc338L":
-                ksym = "add_to_page_cache_lru"
-            elif ksym == "0xffffff80081e9758L":
-                ksym = "account_page_dirtied"
-            elif ksym == "0xffffff8008294694L":
-                ksym = "mark_buffer_dirty"
-            elif ksym == "0xffffff80081eea10L":
-                ksym = "mark_page_accessed"
-            
         if re.match('mark_page_accessed', ksym) is not None:
             mpa = max(0, v.value)
 


### PR DESCRIPTION
This patch:

- Updates the BPFd source in BCC to be in sync with the recent changes related to kernel/user symbol lookup in the BPFd repo
- Fixes a couple of bugs concerning how BCC interacts with BPFd
- Does a bit of clean up and removes some of the HiKey demo hacks
- **Hooks up BCC's kernel/userspace symbol lookup logic to BPFd**, allowing for remote symbol lookup in BCC