### PR TITLE
Add support for attaching to perf_events on remote devices via BPFd

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -841,8 +841,12 @@ class BPF(object):
 
     def _attach_perf_event(self, progfd, ev_type, ev_config,
             sample_period, sample_freq, pid, cpu, group_fd):
-        res = lib.bpf_attach_perf_event(progfd, ev_type, ev_config,
-                sample_period, sample_freq, pid, cpu, group_fd)
+        if BPF._libremote:
+            res = BPF._libremote.bpf_attach_perf_event(progfd, ev_type,
+                    ev_config, sample_period, sample_freq, pid, cpu, group_fd)
+        else:
+            res = lib.bpf_attach_perf_event(progfd, ev_type, ev_config,
+                    sample_period, sample_freq, pid, cpu, group_fd)
         if res < 0:
             raise Exception("Failed to attach BPF to perf event")
         return res

--- a/src/python/bcc/remote/libremote.py
+++ b/src/python/bcc/remote/libremote.py
@@ -298,6 +298,13 @@ class LibRemote(object):
             addr = ret[1][1]
             return addr
 
+    def bpf_attach_perf_event(self, progfd, ev_type, ev_config, sample_period,
+                              sample_freq, pid, cpu, group_fd):
+        cmd = "BPF_ATTACH_PERF_EVENT {} {} {} {} {} {} {} {}".format(progfd,
+                    ev_type, ev_config, sample_period, sample_freq, pid, cpu, group_fd)
+        ret = self._remote_send_command(cmd)
+        return ret[0]
+
     def close_connection(self):
         self._remote_send_command("exit")
         self.remote.close_connection()


### PR DESCRIPTION
This fixes the bug where tools that needed to attach to a perf_event
(like profile.py) were crashing due to BCC's lack of support for
attaching to remote perf_events.

Signed-off-by: Jazel Canseco <jcanseco@google.com>

When approving this PR, please approve the corresponding [BPFd PR](https://github.com/joelagnel/bpfd/pull/41) as well.
Fixes [issue #31 in BPFd repo](https://github.com/joelagnel/bpfd/issues/31).