### PR TITLE
Redirect syscount.py's reads of "comm" files to BPFd for remote targets

### DIFF
--- a/src/python/bcc/__init__.py
+++ b/src/python/bcc/__init__.py
@@ -254,6 +254,16 @@ class BPF(object):
                     return exe_file
         return None
 
+    @staticmethod
+    def comm_for_pid(pid):
+        if BPF._libremote:
+            return BPF._libremote.comm_for_pid(pid)
+        else:
+            try:
+                return open("/proc/%d/comm" % pid).read().strip()
+            except Exception:
+                return "[unknown]"
+
     def __init__(self, src_file="", hdr_file="", text=None, cb=None, debug=0,
             cflags=[], usdt_contexts=[]):
         """Create a new BPF module with the given source code.

--- a/src/python/bcc/remote/libremote.py
+++ b/src/python/bcc/remote/libremote.py
@@ -88,6 +88,17 @@ class LibRemote(object):
         ret = self._remote_send_command(cmd)
         return ret[0] if ret[0] < 0 else ret[1]
 
+    def comm_for_pid(self, pid):
+        cmd = "COMM_FOR_PID {}".format(pid)
+        ret = self._remote_send_command(cmd)
+
+        ret_code = ret[0]
+        if ret_code < 0:
+            return "[unknown]"
+        else:
+            comm = ret[1][0]
+            return comm
+
     def bpf_attach_tracepoint(self, fd, cat, tpname):
         cmd = "BPF_ATTACH_TRACEPOINT {} {} {}".format(fd, cat, tpname)
         ret = self._remote_send_command(cmd)

--- a/tools/syscount.py
+++ b/tools/syscount.py
@@ -477,15 +477,9 @@ def print_stats():
 agg_colname = "PID    COMM" if args.process else "SYSCALL"
 time_colname = "TIME (ms)" if args.milliseconds else "TIME (us)"
 
-def comm_for_pid(pid):
-    try:
-        return open("/proc/%d/comm" % pid).read().strip()
-    except Exception:
-        return "[unknown]"
-
 def agg_colval(key):
     if args.process:
-        return "%-6d %-15s" % (key.value, comm_for_pid(key.value))
+        return "%-6d %-15s" % (key.value, BPF.comm_for_pid(key.value))
     else:
         return syscalls.get(key.value, "[unknown: %d]" % key.value)
 


### PR DESCRIPTION
This queries BPFd for the "comm" file of a given pid when a remote
target is configured. This fixes the issue with syscount.py, which was
reading "comm" files locally instead of on the remote target.

This bug caused "syscount.py -P" to show "[unknown]" when running for a
remote target, since it was erroneously looking up the target's
process pids on the local host.

Signed-off-by: Jazel Canseco <jcanseco@google.com>

Please also approve the corresponding [BPFd PR](https://github.com/joelagnel/bpfd/pull/47).
Fixes [BPFd issue #7](https://github.com/joelagnel/bpfd/issues/7).