### PR TITLE
Fix bug where failed file reads on remote are not detected by libremote

### DIFF
--- a/src/python/bcc/remote/libremote.py
+++ b/src/python/bcc/remote/libremote.py
@@ -52,6 +52,9 @@ class LibRemote(object):
             print('Command not recognized! cmd: {}'.format(cmd))
             return (-1, [])
 
+        if ret[0].startswith('Open failed, ignoring'):
+            return (-1, [])
+
         # Assume success if first list element doesn't have ret=
         if not 'ret=' in ret[0]:
             return (0, ret)


### PR DESCRIPTION
BPFd responds with the message "Open failed, ignoring" when it fails to
open a file it is requested to read out to stdout. Before this patch,
libremote did not account for the fact that BPFd may respond with this
error message, and erroneously let it pass through as a successful
response.

Signed-off-by: Jazel Canseco <jcanseco@google.com>